### PR TITLE
Added support for variables in desig init macros

### DIFF
--- a/cram_designators/src/cram-designators/initialization-macros.lisp
+++ b/cram_designators/src/cram-designators/initialization-macros.lisp
@@ -30,13 +30,15 @@
 (in-package :desig)
 
 (defun variable-value-or-keyword (a-symbol)
-  (if (boundp a-symbol)
-      (if (equal (symbol-value a-symbol) a-symbol)
-          a-symbol ; it's a keyword
-          (variable-value-or-keyword (symbol-value a-symbol))) ; it's a special var
-      (if (eql (aref (string-upcase a-symbol) 0) #\?)
-          a-symbol ; it's a variable (starts with ?, e.g. ?x)
-          (intern (string-upcase a-symbol) :keyword)))) ; it's a simple symbol
+  (if (symbolp a-symbol)
+      (if (boundp a-symbol)
+          (if (equal (symbol-value a-symbol) a-symbol)
+              a-symbol                  ; it's a keyword
+              (variable-value-or-keyword (symbol-value a-symbol))) ; it's a special var
+          (if (eql (aref (string-upcase a-symbol) 0) #\?)
+              a-symbol      ; it's a variable (starts with ?, e.g. ?x)
+              (intern (string-upcase a-symbol) :keyword))) ; it's a simple symbol
+      a-symbol)) ; it's not a symbol but a number or some other actual value
 
 (defun parse-key-value-pairs (key-value-pairs)
   (labels ((parse (key-value-pair-list)

--- a/cram_designators/src/cram-designators/initialization-macros.lisp
+++ b/cram_designators/src/cram-designators/initialization-macros.lisp
@@ -42,7 +42,10 @@
                      (loop for key-value-pair in key-value-pair-list
                            collecting (parse key-value-pair)))
                  (if (symbolp key-value-pair-list)
-                     (intern (string-upcase key-value-pair-list) :keyword)
+                     (handler-case (symbol-value key-value-pair-list)
+                       (unbound-variable (e)
+                         (declare (ignore e))
+                         (intern (string-upcase key-value-pair-list) :keyword)))
                      key-value-pair-list))))
     (parse key-value-pairs)))
 


### PR DESCRIPTION
There is a distinction between dynamic (special, global) variables and lexical (`let` block) variables in the implementation:

* Global variables can be used like this:

   `> (desig:an action (to drive) (timeout cram-tf:*tf-default-timeout*))`

   `#<ACTION-DESIGNATOR ((:TO :DRIVE) (:TIMEOUT 4.0)) {100DE235D3}>`

* Local variables are a bit different, because you can't know their value at compile time.
  So, after a short discussion with Michael we decided to add a syntactical distinction between variable symbols and just symbols, that distinction would be a question mark at the beginning of the variable. E.g.:

   ```lisp
    > (let ((?action 'drive))
        (desig:an action (to ?action) (timeout cram-tf:*tf-default-timeout*)))
   #<ACTION-DESIGNATOR ((:TO DRIVE) (:TIMEOUT 4.0)) {100DE235D3}>
   ```

  Pay attention that the value of the variable, in case it contains a symbol, should be a keyword, the values of variables are not converted to keywords automatically. In our case `DRIVE` stayed `DRIVE` and wasn't converted to `:DRIVE`.
  
  In case you have very weird designator properties that actually start with a question mark you should use them as keywords to differentiate from variables:

   ```lisp
    > (let ((?action 'drive))
        (desig:an action (to :?action) (timeout cram-tf:*tf-default-timeout*)))
   #<ACTION-DESIGNATOR ((:TO :?ACTION) (:TIMEOUT 4.0)) {100F6FB133}>
   ```