### PR TITLE
in cram_process_modules added a small utility function

### DIFF
--- a/cram_process_modules/src/package.lisp
+++ b/cram_process_modules/src/package.lisp
@@ -54,4 +54,4 @@
            on-input on-cancel on-run synchronization-fluent
            finish-process-module fail-process-module monitor-process-module
            matching-process-module available-process-module projection-running
-           matching-process-module-names))
+           matching-process-module-names matching-available-process-modules))


### PR DESCRIPTION
`matching-available-process-modules` finds the module to execute an action designator and issues an failure when none found if `fail-if-none` is set