### PR TITLE
in desigs in initialization macros fixed a bug

### DIFF
--- a/cram_designators/src/cram-designators/initialization-macros.lisp
+++ b/cram_designators/src/cram-designators/initialization-macros.lisp
@@ -49,7 +49,7 @@
                                   '(:a :an :some :the)))
                      (let ((quantifier (first key-value-pair-list))
                            (type-symbol (second key-value-pair-list))
-                           (key-value-pairs-evaluated (cddr key-value-pair-list)))
+                           (key-value-pairs-evaluated (caddr key-value-pair-list)))
                        `(,quantifier ,type-symbol ,key-value-pairs-evaluated))
                      `(list ,@(loop for key-value-pair in key-value-pair-list
                                     collecting (parse key-value-pair))))


### PR DESCRIPTION
Nested designators were getting one bracket too much.

For example, `(desig:an object (type cutlery))` would result in `#<CRAM-DESIGNATORS:OBJECT-DESIGNATOR ((:TYPE :CUTLERY)) {1008C68CB3}>` but `(desig:an action
                     (to grasp)
                     (object (desig:an object (type cutlery))))` would get one bracket too much in the nested object:
`#<CRAM-DESIGNATORS:ACTION-DESIGNATOR ((:TO :GRASP)
                                      (:OBJECT
                                       #<CRAM-DESIGNATORS:OBJECT-DESIGNATOR
                                         (((:TYPE :CUTLERY))) {100FAAB673}>
                                       )) {100FAABA93}>`

This PR fixes that.